### PR TITLE
Fixed whitespace warnings from brew audit --strict

### DIFF
--- a/Formula/vasmm68k.rb
+++ b/Formula/vasmm68k.rb
@@ -1,21 +1,21 @@
 class Vasmm68k < Formula
-    desc "Cross-assembler for 680x0 processors / Amiga OS"
-    homepage "http://sun.hasenbraten.de/vasm"
-    url "http://server.owl.de/~frank/tags/vasm1_8e.tar.gz"
-    version "1.8e"
-    sha256 "abcd1234"
-  
-    def install
-      # ENV.deparallelize
-      system "(make CPU=m68k SYNTAX=mot && chmod ugo+rx vasmm68k_mot)"
-      system "(make CPU=m68k SYNTAX=std && chmod ugo+rx vasmm68k_std)"
-      bin.install "vasmm68k_mot"
-      bin.install "vasmm68k_std"
-    end
-  
-    test do
-    # Disable tests for the time being
-    #    assert_match version.to_s, shell_output("#{bin}/vasmm68k_mot")
-    #    assert_match version.to_s, shell_output("#{bin}/vasmm68k_std")
-    end
+  desc "Cross-assembler for 680x0 processors / Amiga OS"
+  homepage "http://sun.hasenbraten.de/vasm"
+  url "http://server.owl.de/~frank/tags/vasm1_8e.tar.gz"
+  version "1.8e"
+  sha256 "abcd1234"
+
+  def install
+    # ENV.deparallelize
+    system "(make CPU=m68k SYNTAX=mot && chmod ugo+rx vasmm68k_mot)"
+    system "(make CPU=m68k SYNTAX=std && chmod ugo+rx vasmm68k_std)"
+    bin.install "vasmm68k_mot"
+    bin.install "vasmm68k_std"
   end
+
+  test do
+    # Disable tests for the time being
+    # assert_match version.to_s, shell_output("#{bin}/vasmm68k_mot")
+    # assert_match version.to_s, shell_output("#{bin}/vasmm68k_std")
+  end
+end


### PR DESCRIPTION
This removes all strict warnings related to whitespace.

Still remaining:

```
  * stable version should not decrease (from 8f to 1.8e)
  * C: 6: col 11: sha256 should be 64 characters
  * C: 16: col 3: `test do` should not be empty
```