### PR TITLE
Change version_scheme to 1 for vasmm68k

### DIFF
--- a/Formula/vasmm68k.rb
+++ b/Formula/vasmm68k.rb
@@ -4,6 +4,7 @@ class Vasmm68k < Formula
   url "http://server.owl.de/~frank/tags/vasm1_8e.tar.gz"
   version "1.8e"
   sha256 "5f1ebb8b81d2d9664e5c2646f1abbc5fb795642ed117f55e84a66590a62760ff"
+  version_scheme 1
 
   def install
     # ENV.deparallelize


### PR DESCRIPTION
The first commits of vasmm68k accidentally werw without any explicit version. The automatic version detection failed and thought vasm1_8f meant version '8f'. Now that we are providing an explicit version, we also need to bump the version scheme so it doesn't seem like 8f -> 1.8g is a downgrade.